### PR TITLE
feat: Refactor all Bybit logic to V5 API and improve UI

### DIFF
--- a/app/Console/Commands/BybitLifecycle.php
+++ b/app/Console/Commands/BybitLifecycle.php
@@ -1,73 +1,91 @@
 <?php
 
-// app/Console/Commands/BybitLifecycle.php
 namespace App\Console\Commands;
 
 use App\Models\BybitOrders;
+use App\Services\BybitApiService;
 use Illuminate\Console\Command;
 
 class BybitLifecycle extends Command
 {
     protected $signature = 'bybit:lifecycle';
-    protected $description = 'اعمال انقضا و گذاشتن اردر کلوز TP برای سفارش‌های پر شده';
+    protected $description = 'Manages expiration and places TP close orders for filled orders.';
+
+    protected $bybitApiService;
+
+    public function __construct(BybitApiService $bybitApiService)
+    {
+        parent::__construct();
+        $this->bybitApiService = $bybitApiService;
+    }
 
     public function handle(): int
     {
-        require_once base_path('vendor/autoload.php');
-
-        $exchange = new \ccxt\bybit([
-            'apiKey' => env('BYBIT_API_KEY'),
-            'secret' => env('BYBIT_API_SECRET'),
-            'enableRateLimit' => true,
-            'options' => [
-                'defaultType' => 'unified',
-                'recvWindow' => 5000,
-                'adjustForTimeDifference' => true
-            ]
-        ]);
-        if (env('BYBIT_TESTNET', false)) {
-            $exchange->set_sandbox_mode(true);
-        }
-
+        $this->info('Starting order lifecycle management...');
         $now = time();
 
-        // 1) اگر زمان انقضا گذشته و هنوز open است: لغو
-        $pendings = BybitOrders::where('status','pending')->get();
-        foreach ($pendings as $row) {
+        $pendingDbOrders = BybitOrders::where('status', 'pending')->get();
+        $this->info("Found " . $pendingDbOrders->count() . " pending orders in the database to check.");
+
+        foreach ($pendingDbOrders as $dbOrder) {
             try {
-                $o = $exchange->fetchOrder($row->order_id, $row->symbol);
-                if ($o && isset($o['status'])) {
-                    if ($o['status'] === 'open') {
-                        $expireAt = $row->created_at->timestamp + ($row->expire_minutes * 60);
-                        if ($now >= $expireAt) {
-                            $exchange->cancelOrder($row->order_id, $row->symbol);
-                            $row->status = 'canceled';
-                            $row->save();
-                            $this->info("Canceled expired order {$row->order_id}");
-                        }
-                    } elseif ($o['status'] === 'closed') {
-                        // 2) اگر پر شد، اردر کلوز در TP بگذار
-                        $closeSide = ($row->side === 'buy') ? 'sell' : 'buy';
-                        $tpPrice   = (float)$row->tp;
+                // V5 API uses orderId, not a combination of ID and symbol
+                $orderResult = $this->bybitApiService->getHistoryOrder($dbOrder->order_id);
+                $order = $orderResult['list'][0] ?? null;
 
-                        $exchange->createOrder($row->symbol, 'limit', $closeSide, (float)$row->amount, $tpPrice, [
-                            'reduceOnly'  => true,
-                            'timeInForce' => 'GTC',
-                        ]);
+                if (!$order) {
+                    $this->warn("Could not fetch order details for DB order ID {$dbOrder->id} (Bybit ID: {$dbOrder->order_id}).");
+                    continue;
+                }
 
-                        $row->status = 'filled';
-                        $row->save();
-                        $this->info("Placed TP close for {$row->order_id} at {$tpPrice}");
-                    } elseif ($o['status'] === 'canceled') {
-                        $row->status = 'canceled';
-                        $row->save();
+                $bybitStatus = $order['orderStatus'];
+                $symbol = $order['symbol'];
+
+                // 1) If the order is still open (V5 status 'New') and expired, cancel it.
+                if ($bybitStatus === 'New') {
+                    $expireAt = $dbOrder->created_at->timestamp + ($dbOrder->expire_minutes * 60);
+                    if ($now >= $expireAt) {
+                        $this->bybitApiService->cancelOrder($dbOrder->order_id, $symbol);
+                        $dbOrder->status = 'canceled';
+                        $dbOrder->save();
+                        $this->info("Canceled expired order: {$dbOrder->order_id}");
                     }
                 }
+                // 2) If the order is filled, place the TP close order.
+                elseif ($bybitStatus === 'Filled') {
+                    $closeSide = (strtolower($dbOrder->side) === 'buy') ? 'Sell' : 'Buy';
+                    $tpPrice = (float)$dbOrder->tp;
+
+                    $tpOrderParams = [
+                        'category' => 'linear',
+                        'symbol' => $symbol,
+                        'side' => $closeSide,
+                        'orderType' => 'Limit',
+                        'qty' => (string)$dbOrder->amount,
+                        'price' => (string)$tpPrice,
+                        'reduceOnly' => true,
+                        'timeInForce' => 'GTC',
+                    ];
+
+                    $this->bybitApiService->createOrder($tpOrderParams);
+
+                    $dbOrder->status = 'filled';
+                    $dbOrder->save();
+                    $this->info("Placed TP close order for filled order: {$dbOrder->order_id} at price {$tpPrice}");
+                }
+                // 3) If the order was canceled on the exchange, update our DB.
+                elseif (in_array($bybitStatus, ['Cancelled', 'Deactivated'])) {
+                    $dbOrder->status = 'canceled';
+                    $dbOrder->save();
+                    $this->info("Marked order {$dbOrder->order_id} as canceled to match exchange status.");
+                }
+
             } catch (\Throwable $e) {
-                $this->warn("Lifecycle check failed for {$row->order_id}: ".$e->getMessage());
+                $this->error("Lifecycle check failed for our order ID {$dbOrder->id} (Bybit ID {$dbOrder->order_id}): " . $e->getMessage());
             }
         }
 
+        $this->info('Finished order lifecycle management.');
         return self::SUCCESS;
     }
 }

--- a/app/Console/Commands/CheckBybitOrders.php
+++ b/app/Console/Commands/CheckBybitOrders.php
@@ -3,51 +3,59 @@
 namespace App\Console\Commands;
 
 use App\Models\BybitOrders;
+use App\Services\BybitApiService;
 use Illuminate\Console\Command;
 
 class CheckBybitOrders extends Command
 {
     protected $signature = 'bybit:check-orders';
-    protected $description = 'بررسی و حذف سفارش‌های منقضی';
+    protected $description = 'Checks for and cancels expired pending orders.';
+
+    protected $bybitApiService;
+
+    public function __construct(BybitApiService $bybitApiService)
+    {
+        parent::__construct();
+        $this->bybitApiService = $bybitApiService;
+    }
 
     public function handle()
     {
-        require_once base_path('vendor/autoload.php');
+        $this->info('Checking for expired orders...');
+        $now = time();
 
-        $apiKey    = env('BYBIT_API_KEY');
-        $apiSecret = env('BYBIT_API_SECRET');
-        $testnet   = env('BYBIT_TESTNET', false);
+        $pendingDbOrders = BybitOrders::where('status', 'pending')->get();
+        $this->info("Found " . $pendingDbOrders->count() . " pending orders to check for expiration.");
 
-        $exchange = new \ccxt\bybit([
-            'apiKey' => $apiKey,
-            'secret' => $apiSecret,
-            'enableRateLimit' => true,
-            'options' => [
-                'defaultType' => 'unified',
-                'recvWindow' => 5000,
-                'adjustForTimeDifference' => true
-            ]
-        ]);
+        foreach ($pendingDbOrders as $dbOrder) {
+            $expireAt = $dbOrder->created_at->timestamp + ($dbOrder->expire_minutes * 60);
 
-        if ($testnet) {
-            $exchange->set_sandbox_mode(true);
-        }
+            if ($now >= $expireAt) {
+                try {
+                    // Fetch the order from Bybit to ensure it's still 'New' (i.e., open and not filled)
+                    $orderResult = $this->bybitApiService->getHistoryOrder($dbOrder->order_id);
+                    $order = $orderResult['list'][0] ?? null;
 
-        $orders = BybitOrders::where('status', 'pending')->get();
+                    if ($order && $order['orderStatus'] === 'New') {
+                        $this->bybitApiService->cancelOrder($dbOrder->order_id, $order['symbol']);
+                        $dbOrder->status = 'canceled';
+                        $dbOrder->save();
+                        $this->info("Canceled expired order: {$dbOrder->order_id}");
+                    } elseif ($order && $order['orderStatus'] !== 'New') {
+                        // If it's filled or already canceled, we can just update our DB
+                        // This logic is better handled by BybitLifecycle, but we'll log it here.
+                        $this->info("Order {$dbOrder->order_id} is no longer 'New' on the exchange (Status: {$order['orderStatus']}). Skipping cancellation.");
+                        // To be robust, you might want to update the status here too.
+                        // $dbOrder->status = strtolower($order['orderStatus']);
+                        // $dbOrder->save();
+                    }
 
-        foreach ($orders as $order) {
-            $createdAt = $order->created_at->timestamp;
-            $expireAt = $createdAt + ($order->expire_minutes * 60);
-
-            if (time() >= $expireAt) {
-                $o = $exchange->fetch_order($order->order_id, $order->symbol);
-                if ($o['status'] === 'open') {
-                    $exchange->cancel_order($order->order_id, $order->symbol);
-                    $order->status = 'canceled';
-                    $order->save();
-                    $this->info("Order {$order->order_id} canceled.");
+                } catch (\Throwable $e) {
+                    $this->error("Failed to process order ID {$dbOrder->order_id}: " . $e->getMessage());
                 }
             }
         }
+        $this->info('Finished checking for expired orders.');
+        return self::SUCCESS;
     }
 }

--- a/app/Services/BybitApiService.php
+++ b/app/Services/BybitApiService.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Http;
+
+class BybitApiService
+{
+    private $apiKey;
+    private $apiSecret;
+    private $baseUrl;
+    private $recvWindow = 5000;
+
+    public function __construct()
+    {
+        $this->apiKey = env('BYBIT_API_KEY');
+        $this->apiSecret = env('BYBIT_API_SECRET');
+        $isTestnet = env('BYBIT_TESTNET', false);
+        $this->baseUrl = $isTestnet ? 'https://api-testnet.bybit.com' : 'https://api.bybit.com';
+    }
+
+    private function generateSignature(string $payload): string
+    {
+        return hash_hmac('sha256', $payload, $this->apiSecret);
+    }
+
+    private function sendRequest(string $method, string $endpoint, array $params = [])
+    {
+        $timestamp = intval(microtime(true) * 1000);
+
+        $payloadToSign = '';
+        if ($method === 'GET') {
+            $queryString = http_build_query($params, '', '&');
+            $payloadToSign = $timestamp . $this->apiKey . $this->recvWindow . $queryString;
+        } else { // POST
+            $jsonPayload = json_encode($params);
+            $payloadToSign = $timestamp . $this->apiKey . $this->recvWindow . $jsonPayload;
+        }
+
+        $signature = $this->generateSignature($payloadToSign);
+
+        $headers = [
+            'X-BAPI-API-KEY' => $this->apiKey,
+            'X-BAPI-SIGN' => $signature,
+            'X-BAPI-TIMESTAMP' => $timestamp,
+            'X-BAPI-RECV-WINDOW' => $this->recvWindow,
+            'Content-Type' => 'application/json',
+        ];
+
+        $response = $method === 'GET'
+            ? Http::withHeaders($headers)->get("{$this->baseUrl}{$endpoint}", $params)
+            : Http::withHeaders($headers)->post("{$this->baseUrl}{$endpoint}", $params);
+
+        $responseData = $response->json();
+
+        if ($response->failed() || $responseData['retCode'] !== 0) {
+            throw new \Exception($responseData['retMsg'] ?? 'Bybit API request failed.');
+        }
+
+        return $responseData['result'];
+    }
+
+    public function getInstrumentsInfo(string $symbol)
+    {
+        return $this->sendRequest('GET', '/v5/market/instruments-info', ['category' => 'linear', 'symbol' => $symbol]);
+    }
+
+    public function createOrder(array $params)
+    {
+        return $this->sendRequest('POST', '/v5/order/create', $params);
+    }
+
+    public function getOpenOrders(string $symbol)
+    {
+        return $this->sendRequest('GET', '/v5/order/realtime', ['category' => 'linear', 'symbol' => $symbol]);
+    }
+
+    public function getHistoryOrder(string $orderId)
+    {
+        return $this->sendRequest('GET', '/v5/order/history', ['category' => 'linear', 'orderId' => $orderId]);
+    }
+
+    public function cancelOrder(string $orderId, string $symbol)
+    {
+        return $this->sendRequest('POST', '/v5/order/cancel', ['category' => 'linear', 'orderId' => $orderId, 'symbol' => $symbol]);
+    }
+}


### PR DESCRIPTION
This commit delivers a comprehensive update to the Bybit integration, migrating all functionality from the `cctx` library to a direct V5 API implementation and overhauling the frontend form.

**Core Refactoring:**
- A new `BybitApiService` was created to centralize all Bybit V5 API interactions, including authentication, placing orders, fetching order status, and canceling orders.
- This service is now used by both the web controller and the Artisan commands.

**Frontend (set_order.blade.php):**
- Overhauled the UI for a modern, clean, and responsive design.
- Implemented robust error handling to display both validation and controller-level errors.
- Ensured user input is preserved upon submission failure.

**Backend (Controller & Commands):**
- Refactored `BybitController` to be a slim controller that uses the `BybitApiService`.
- Refactored all Artisan commands (`BybitEnforceOrders`, `BybitLifecycle`, `CheckBybitOrders`) to use the new `BybitApiService`, removing all `cctx` usage.

**Configuration:**
- Added the necessary POST route for order submission in `routes/web.php`.
- Removed the `ccxt/ccxt` package from `composer.json` as it is now fully obsolete.