### PR TITLE
feat: Complete Bybit V5 API migration, improve UI, and add SL sync

### DIFF
--- a/app/Console/Commands/SyncStopLoss.php
+++ b/app/Console/Commands/SyncStopLoss.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\BybitOrders;
+use App\Services\BybitApiService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class SyncStopLoss extends Command
+{
+    protected $signature = 'bybit:sync-sl';
+    protected $description = 'Checks active positions and resets the Stop Loss if it has been changed on the exchange.';
+
+    protected $bybitApiService;
+
+    public function __construct(BybitApiService $bybitApiService)
+    {
+        parent::__construct();
+        $this->bybitApiService = $bybitApiService;
+    }
+
+    public function handle(): int
+    {
+        $this->info('Starting Stop Loss synchronization...');
+
+        // Get all orders that should have an active position on the exchange
+        $filledOrders = BybitOrders::where('status', 'filled')->get();
+
+        if ($filledOrders->isEmpty()) {
+            $this->info('No filled orders found in the database. Nothing to sync.');
+            return self::SUCCESS;
+        }
+
+        // Group orders by symbol to make fewer API calls
+        $groupedOrders = $filledOrders->groupBy('symbol');
+
+        foreach ($groupedOrders as $symbol => $orders) {
+            try {
+                $positionInfoResult = $this->bybitApiService->getPositionInfo($symbol);
+                $positions = $positionInfoResult['list'] ?? [];
+
+                if (empty($positions)) {
+                    $this->warn("No open positions found for symbol {$symbol} on Bybit.");
+                    continue;
+                }
+
+                foreach ($orders as $dbOrder) {
+                    // Find the matching position from the API response
+                    // V5 API side values: 'Buy', 'Sell', 'None'
+                    $matchingPosition = null;
+                    foreach ($positions as $pos) {
+                        // Position side 'Buy' matches our 'buy' orders, 'Sell' matches 'sell'
+                        if (strtolower($pos['side']) === strtolower($dbOrder->side)) {
+                            $matchingPosition = $pos;
+                            break;
+                        }
+                    }
+
+                    if (!$matchingPosition) {
+                        Log::warning("Could not find matching Bybit position for our filled order ID: {$dbOrder->id}");
+                        continue;
+                    }
+
+                    $exchangeSl = (float)($matchingPosition['stopLoss'] ?? 0);
+                    $databaseSl = (float)$dbOrder->sl;
+
+                    // Compare SL, allowing for floating point inaccuracies
+                    if (abs($exchangeSl - $databaseSl) > 0.00001) {
+                        $this->warn("SL mismatch for {$symbol} (Side: {$dbOrder->side}). Exchange: {$exchangeSl}, DB: {$databaseSl}. Resetting...");
+
+                        $params = [
+                            'category' => 'linear',
+                            'symbol' => $symbol,
+                            'stopLoss' => (string)$databaseSl,
+                            // We must also provide the takeProfit, otherwise it will be removed.
+                            // Assuming TP from the first leg is the one we want to maintain.
+                            'takeProfit' => (string)$dbOrder->tp,
+                        ];
+
+                        $this->bybitApiService->setTradingStop($params);
+                        $this->info("Successfully reset SL for {$symbol} to {$databaseSl}.");
+                    } else {
+                        $this->info("SL for {$symbol} (Side: {$dbOrder->side}) is in sync.");
+                    }
+                }
+            } catch (\Throwable $e) {
+                $this->error("Failed to sync SL for symbol {$symbol}: " . $e->getMessage());
+                Log::error("Bybit SL Sync Error for {$symbol}: " . $e->getMessage(), ['exception' => $e]);
+            }
+        }
+
+        $this->info('Finished Stop Loss synchronization.');
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/BybitApiService.php
+++ b/app/Services/BybitApiService.php
@@ -84,4 +84,14 @@ class BybitApiService
     {
         return $this->sendRequest('POST', '/v5/order/cancel', ['category' => 'linear', 'orderId' => $orderId, 'symbol' => $symbol]);
     }
+
+    public function getPositionInfo(string $symbol)
+    {
+        return $this->sendRequest('GET', '/v5/position/list', ['category' => 'linear', 'symbol' => $symbol]);
+    }
+
+    public function setTradingStop(array $params)
+    {
+        return $this->sendRequest('POST', '/v5/position/set-trading-stop', $params);
+    }
 }


### PR DESCRIPTION
This commit delivers a comprehensive update to the Bybit integration. It migrates all functionality from the `cctx` library to a direct V5 API implementation, overhauls the frontend form, and adds a new feature to synchronize stop-loss values.

**Core Refactoring:**
- A new `BybitApiService` was created to centralize all Bybit V5 API interactions, including position management.
- This service is now used by both the web controller and all Artisan commands.
- The `ccxt/ccxt` dependency has been completely removed.

**New Features:**
- Added a new Artisan command `bybit:sync-sl`.
- This command checks all active positions and resets the Stop Loss on the exchange if it deviates from the value stored in the local database, preventing manual SL changes.

**Frontend (set_order.blade.php):**
- Overhauled the UI for a modern, clean, and responsive design.
- Implemented robust error handling to display both validation and controller-level errors.
- Ensured user input is preserved upon submission failure.

**Backend (Controller & Commands):**
- Refactored `BybitController` to be a slim controller that uses the `BybitApiService`.
- Refactored all existing Artisan commands (`BybitEnforceOrders`, `BybitLifecycle`, `CheckBybitOrders`) to use the new `BybitApiService`.