### PR TITLE
feat: Full Bybit V5 API migration and feature enhancement

### DIFF
--- a/app/Console/Commands/CheckBybitOrders.php
+++ b/app/Console/Commands/CheckBybitOrders.php
@@ -24,8 +24,11 @@ class CheckBybitOrders extends Command
         $this->info('Checking for expired orders...');
         $now = time();
 
-        $pendingDbOrders = BybitOrders::where('status', 'pending')->get();
-        $this->info("Found " . $pendingDbOrders->count() . " pending orders to check for expiration.");
+        $pendingDbOrders = BybitOrders::where('status', 'pending')
+            ->where('symbol', 'ETHUSDT')
+            ->get();
+
+        $this->info("Found " . $pendingDbOrders->count() . " pending ETHUSDT orders to check for expiration.");
 
         foreach ($pendingDbOrders as $dbOrder) {
             $expireAt = $dbOrder->created_at->timestamp + ($dbOrder->expire_minutes * 60);


### PR DESCRIPTION
This commit delivers a comprehensive update to the Bybit integration. It migrates all functionality from the `cctx` library to a direct V5 API implementation, overhauls the frontend, and adds several new features for risk management, security, and UI.

**Core Refactoring:**
- A new `BybitApiService` was created to centralize all Bybit V5 API interactions.
- All controllers and Artisan commands now use this service.
- The `ccxt/ccxt` dependency has been completely removed.

**Risk Management & Trading Logic:**
- Order size calculation is now based on a user-configurable risk percentage (capped at 10%).
- The application fetches the live USDT wallet balance from Bybit before every trade to use in risk calculations.
- Added server-side validation to prevent placing limit orders that would execute immediately.
- The number of steps is now automatically set to 1 if the entry prices are identical.

**Security & Safety:**
- The order submission form is now protected by a password defined in the `.env` file.
- All Artisan commands are now hardcoded to only operate on the 'ETHUSDT' symbol to prevent accidental manipulation of other markets.

**New Features & UI:**
- The order form now pre-fills with the rounded, current market price on page load.
- A new responsive page has been added to list all submitted orders with the ability to delete them.
- Numbers in the order list are formatted to two decimal places.
- Added a new Artisan command `bybit:sync-sl` to prevent SL deviation on active positions.
- Fixed an issue where number inputs would render with Persian numerals by default.

**Backend (Controller & Commands):**
- Refactored `BybitController` and all Artisan commands to use the new `BybitApiService`.
- Corrected logic in `BybitLifecycle` to ensure TP orders are created for filled positions.