### PR TITLE
Fix parameter formatting in SyncStopLoss command

### DIFF
--- a/app/Console/Commands/SyncStopLoss.php
+++ b/app/Console/Commands/SyncStopLoss.php
@@ -76,7 +76,7 @@ class SyncStopLoss extends Command
                         'category'    => 'linear',
                         'symbol'      => $symbol,
                         'stopLoss'    => (string)$databaseSl,
-                        'takeProfit'  => (string)($matchingPosition['takeProfit'] ?? '0'),
+                        'takeProfit'  => (string)(float)($matchingPosition['takeProfit'] ?? 0),
                         'tpslMode'    => $matchingPosition['tpslMode'] ?? 'Full',
                         'tpTriggerBy' => $matchingPosition['tpTriggerBy'] ?? 'LastPrice',
                         'slTriggerBy' => $matchingPosition['slTriggerBy'] ?? 'LastPrice',


### PR DESCRIPTION
- Fixes a bug in the `SyncStopLoss` command where the `setTradingStop` API call would fail if no take profit was set on the exchange position.
- The `takeProfit` parameter was being sent as an empty string (""), which is an invalid value for the Bybit API.
- The code is updated to cast the value to a float and then back to a string, ensuring that empty or null values are correctly formatted as "0". This resolves the API error.
- This commit builds upon the previous refactoring and fixes for the order management commands.