### PR TITLE
Implement order list improvements and P&L display

### DIFF
--- a/app/Console/Commands/BybitLifecycle.php
+++ b/app/Console/Commands/BybitLifecycle.php
@@ -66,10 +66,14 @@ class BybitLifecycle extends Command
 
                     // If no position exists or its size is 0, it means it has been closed.
                     if (!$position || (float)$position['size'] === 0.0) {
+                        $pnlResult = $this->bybitApiService->getClosedPnl($symbol, 1);
+                        $lastPnl = $pnlResult['list'][0]['closedPnl'] ?? null;
+
                         $dbOrder->status = 'closed';
+                        $dbOrder->pnl = $lastPnl;
                         $dbOrder->closed_at = now();
                         $dbOrder->save();
-                        $this->info("Position for order {$dbOrder->order_id} is closed. Marked as 'closed' in DB.");
+                        $this->info("Position for order {$dbOrder->order_id} is closed. P&L: {$lastPnl}. Marked as 'closed' in DB.");
                     }
                 }
             } catch (\Throwable $e) {

--- a/app/Http/Controllers/BybitController.php
+++ b/app/Http/Controllers/BybitController.php
@@ -17,7 +17,15 @@ class BybitController extends Controller
 
     public function index()
     {
-        $orders = BybitOrders::latest()->paginate(20);
+        $threeDaysAgo = now()->subDays(3);
+
+        $orders = BybitOrders::where(function ($query) use ($threeDaysAgo) {
+            $query->whereIn('status', ['pending', 'filled'])
+                  ->orWhere('updated_at', '>=', $threeDaysAgo);
+        })
+        ->latest('updated_at')
+        ->paginate(50);
+
         return view('orders_list', ['orders' => $orders]);
     }
 

--- a/app/Services/BybitApiService.php
+++ b/app/Services/BybitApiService.php
@@ -98,6 +98,15 @@ class BybitApiService
         return $this->sendRequest('POST', '/v5/position/set-trading-stop', $params);
     }
 
+    public function getClosedPnl(string $symbol, int $limit = 1)
+    {
+        return $this->sendRequest('GET', '/v5/position/closed-pnl', [
+            'category' => 'linear',
+            'symbol' => $symbol,
+            'limit' => $limit,
+        ]);
+    }
+
     public function getWalletBalance(string $accountType = 'UNIFIED', ?string $coin = null)
     {
         $params = ['accountType' => $accountType];

--- a/database/migrations/2025_08_13_113500_create_bybit_orders_table.php
+++ b/database/migrations/2025_08_13_113500_create_bybit_orders_table.php
@@ -28,6 +28,7 @@ class CreateBybitOrdersTable extends Migration
             $table->integer('leverage')->default(1);
             $table->integer('expire_minutes')->default(15);
             $table->string('status')->default('pending'); // pending, filled, canceled, closed
+            $table->decimal('pnl', 20, 10)->nullable();
             $table->timestamp('closed_at')->nullable();
             $table->timestamps();
         });

--- a/resources/views/orders_list.blade.php
+++ b/resources/views/orders_list.blade.php
@@ -159,7 +159,7 @@
                     <th>مقدار</th>
                     <th>TP / SL</th>
                     <th>وضعیت</th>
-                    <th>تاریخ ثبت</th>
+                    <th>P&L</th>
                     <th>عملیات</th>
                 </tr>
             </thead>
@@ -171,7 +171,15 @@
                         <td data-label="مقدار">{{ number_format($order->amount, 2) }}</td>
                         <td data-label="TP / SL">{{ number_format($order->tp, 2) }} / {{ number_format($order->sl, 2) }}</td>
                         <td data-label="وضعیت">{{ $order->status }}</td>
-                        <td data-label="تاریخ ثبت">{{ $order->created_at->format('Y-m-d H:i') }}</td>
+                        <td data-label="P&L">
+                            @if($order->status === 'closed' && !is_null($order->pnl))
+                                <span style="color: {{ $order->pnl >= 0 ? 'green' : 'red' }};">
+                                    {{ number_format($order->pnl, 4) }}
+                                </span>
+                            @else
+                                -
+                            @endif
+                        </td>
                         <td data-label="عملیات">
                             <form action="{{ route('orders.destroy', $order) }}" method="POST" style="display:inline;" onsubmit="return confirm('آیا از حذف این سفارش مطمئن هستید؟');">
                                 @csrf


### PR DESCRIPTION
- Adds a P&L column to the orders table to store realized profit and loss.
- Updates the BybitLifecycle command to fetch and store the P&L for closed positions from the Bybit API.
- Modifies the BybitController to filter the order list, showing only orders from the last 3 days unless they are still active ('pending' or 'filled').
- Updates the `orders_list` view to remove the creation date and add a new column to display the P&L for closed orders, with color-coding for profit (green) and loss (red).
- This commit also includes previous fixes and refactorings for the order management commands.