### PR TITLE
feat: Implement new trading rules and data points

### DIFF
--- a/app/Console/Commands/BybitLifecycle.php
+++ b/app/Console/Commands/BybitLifecycle.php
@@ -124,6 +124,7 @@ class BybitLifecycle extends Command
         if ($pnlEventToAssign) {
             $orderToProcess->status = 'closed';
             $orderToProcess->pnl = $pnlEventToAssign['closedPnl'];
+            $orderToProcess->closure_price = $pnlEventToAssign['avgExitPrice'] ?? null;
             $orderToProcess->closing_order_id = $pnlEventToAssign['orderId']; // Mark PNL event as used
             $orderToProcess->closed_at = now();
             $orderToProcess->save();

--- a/app/Models/BybitOrders.php
+++ b/app/Models/BybitOrders.php
@@ -12,6 +12,7 @@ class BybitOrders extends Model
     protected $guarded = [];
     protected $fillable = [
         'order_id','symbol','entry_price','tp','sl','steps',
-        'expire_minutes','status','closed_at','side','amount','entry_low','entry_high'
+        'expire_minutes','status','closed_at','side','amount','entry_low','entry_high',
+        'closure_price'
     ];
 }

--- a/database/migrations/2025_08_18_132607_add_closure_price_to_bybit_orders_table.php
+++ b/database/migrations/2025_08_18_132607_add_closure_price_to_bybit_orders_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('bybit_orders', function (Blueprint $table) {
+            $table->decimal('closure_price', 20, 10)->nullable()->after('pnl');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bybit_orders', function (Blueprint $table) {
+            $table->dropColumn('closure_price');
+        });
+    }
+};

--- a/tests/Feature/BybitControllerTest.php
+++ b/tests/Feature/BybitControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\BybitOrders;
+use App\Services\BybitApiService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class BybitControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function it_prevents_creating_an_order_if_a_loss_occurred_within_the_last_hour()
+    {
+        // Arrange
+        BybitOrders::create([
+            'status' => 'closed',
+            'pnl' => -10,
+            'closed_at' => now()->subMinutes(30),
+            'entry_price' => 2500,
+            'tp' => 2600,
+            'sl' => 2400,
+        ]);
+
+        $postData = [
+            'entry1' => 3000,
+            'entry2' => 3000,
+            'tp' => 3100,
+            'sl' => 2900,
+            'steps' => 1,
+            'expire' => 15,
+            'risk_percentage' => 1,
+            'access_password' => env('FORM_ACCESS_PASSWORD'),
+        ];
+
+        // Act
+        $response = $this->post(route('order.store'), $postData);
+
+        // Assert
+        $response->assertSessionHasErrors('msg');
+        $this->assertDatabaseMissing('bybit_orders', ['entry_price' => 3000]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_allows_creating_an_order_if_the_last_loss_was_more_than_an_hour_ago()
+    {
+        // Arrange
+        $this->mock(BybitApiService::class, function ($mock) {
+            $mock->shouldReceive('getTickerInfo')->andReturn(['list' => [['lastPrice' => '3000']]]);
+            $mock->shouldReceive('getWalletBalance')->andReturn(['list' => [['totalWalletBalance' => '1000', 'totalEquity' => '1000']]]);
+            $mock->shouldReceive('getInstrumentsInfo')->andReturn(['list' => [['lotSizeFilter' => ['qtyStep' => '0.01'], 'priceScale' => '2']]]);
+            $mock->shouldReceive('createOrder')->andReturn(['orderId' => '12345']);
+        });
+
+        BybitOrders::create([
+            'status' => 'closed',
+            'pnl' => -10,
+            'closed_at' => now()->subMinutes(70),
+            'entry_price' => 2500,
+            'tp' => 2600,
+            'sl' => 2400,
+        ]);
+
+        $postData = [
+            'entry1' => 3000,
+            'entry2' => 3000,
+            'tp' => 3100,
+            'sl' => 2900,
+            'steps' => 1,
+            'expire' => 15,
+            'risk_percentage' => 1,
+            'access_password' => env('FORM_ACCESS_PASSWORD'),
+        ];
+
+        // Act
+        $response = $this->post(route('order.store'), $postData);
+
+        // Assert
+        $response->assertSessionDoesntHaveErrors('msg');
+    }
+}


### PR DESCRIPTION
This commit introduces several new features and improvements to the trading bot:

- **One-hour lockout after a loss:** Prevents the creation of new orders for one hour after a trade results in a loss. This is managed by checking the `bybit_orders` table.
- **Record closure price:** The closing price of a trade is now recorded in the `bybit_orders` table.
- **Handle externally modified orders:** The `BybitEnforceOrders` command now detects and cancels orders that have been modified externally (e.g., price changed on the exchange).