### PR TITLE
feat: Implement new trading rules and data points

### DIFF
--- a/app/Http/Controllers/BybitController.php
+++ b/app/Http/Controllers/BybitController.php
@@ -66,6 +66,12 @@ class BybitController extends Controller
         }
 
         try {
+            // Check for existing active orders
+            $activeOrder = BybitOrders::whereIn('status', ['pending', 'filled'])->first();
+            if ($activeOrder) {
+                return back()->withErrors(['msg' => 'An order is already active. Cannot create a new one.'])->withInput();
+            }
+
             // Check for recent loss
             $lastLoss = BybitOrders::where('status', 'closed')
                 ->where('pnl', '<', 0)

--- a/tests/Feature/BybitControllerTest.php
+++ b/tests/Feature/BybitControllerTest.php
@@ -85,4 +85,36 @@ class BybitControllerTest extends TestCase
         // Assert
         $response->assertSessionDoesntHaveErrors('msg');
     }
+
+    /**
+     * @test
+     */
+    public function it_prevents_creating_an_order_if_another_order_is_already_active()
+    {
+        // Arrange
+        BybitOrders::create([
+            'status' => 'pending', // or 'filled'
+            'entry_price' => 2500,
+            'tp' => 2600,
+            'sl' => 2400,
+        ]);
+
+        $postData = [
+            'entry1' => 3000,
+            'entry2' => 3000,
+            'tp' => 3100,
+            'sl' => 2900,
+            'steps' => 1,
+            'expire' => 15,
+            'risk_percentage' => 1,
+            'access_password' => env('FORM_ACCESS_PASSWORD'),
+        ];
+
+        // Act
+        $response = $this->post(route('order.store'), $postData);
+
+        // Assert
+        $response->assertSessionHasErrors('msg');
+        $this->assertDatabaseCount('bybit_orders', 1); // Ensure no new order was created
+    }
 }


### PR DESCRIPTION
This commit introduces several new features and improvements to the trading bot:

- **One-hour lockout after a loss:** Prevents the creation of new orders for one hour after a trade results in a loss. This is managed by checking the `bybit_orders` table.
- **One active position:** The system now enforces that only one position can be active at a time.
- **Record closure price:** The closing price of a trade is now recorded in the `bybit_orders` table.
- **Handle externally modified orders:** The `BybitEnforceOrders` command now detects and cancels orders that have been modified externally (e.g., price changed on the exchange).
- **Reliable P&L processing:** The P&L processing logic is simplified based on the one-active-position rule, making it more reliable.