### PR TITLE
feat: Implement new trading rules and data points

### DIFF
--- a/app/Http/Controllers/BybitController.php
+++ b/app/Http/Controllers/BybitController.php
@@ -181,6 +181,11 @@ class BybitController extends Controller
 
     public function destroy(BybitOrders $bybitOrder)
     {
+        // Prevent deleting orders that were closed less than 24 hours ago
+        if ($bybitOrder->status === 'closed' && $bybitOrder->closed_at && now()->diffInHours($bybitOrder->closed_at) < 24) {
+            return redirect()->route('orders.index')->withErrors(['msg' => 'Cannot delete an order that was closed less than 24 hours ago.']);
+        }
+
         try {
             // Only try to cancel on the exchange if the order is in a state that might be active
             if ($bybitOrder->status === 'pending' && $bybitOrder->order_id) {


### PR DESCRIPTION
This commit introduces several new features and improvements to the trading bot:

- **One-hour lockout after a loss:** Prevents the creation of new orders for one hour after a trade results in a loss. This is managed by checking the `bybit_orders` table.
- **One active position:** The system now enforces that only one position can be active at a time.
- **Record closure price:** The closing price of a trade is now recorded in the `bybit_orders` table.
- **Handle externally modified orders:** The `BybitEnforceOrders` command now detects and cancels orders that have been modified externally (e.g., price changed on the exchange).
- **Reliable P&L processing:** The P&L processing logic is simplified based on the one-active-position rule, making it more reliable.
- **Prevent deletion of recent orders:** Prevents the deletion of orders that were closed less than 24 hours ago.