### PR TITLE
feat: Implement new order list features

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -54,4 +54,5 @@ Route::get('/schedule', function() {
 Route::get('/set-order', [BybitController::class, 'create'])->name('order.create');
 Route::post('/set-order', [BybitController::class, 'store'])->name('order.store');
 Route::get('/orders', [BybitController::class, 'index'])->name('orders.index');
+Route::post('/orders/{bybitOrder}/close', [BybitController::class, 'close'])->name('orders.close');
 Route::delete('/orders/{bybitOrder}', [BybitController::class, 'destroy'])->name('orders.destroy');


### PR DESCRIPTION
This commit introduces several new features and improvements to the order list page:
- **Display Account Equity:** The total account equity is now displayed on the order list page.
- **Dynamic Action Buttons:** The action buttons on the order list are now dynamic based on the order status (Revoke, Close, Remove).
- **Manual Close Functionality:** Users can now manually close a filled order by providing a price distance. This will cancel the existing TP order and create a new closing order.
- **Updated Destroy Logic:** The logic for deleting orders has been updated to handle pending and expired orders correctly.