### PR TITLE
fix: Fix return type in BybitLifecycle command

### DIFF
--- a/app/Console/Commands/BybitLifecycle.php
+++ b/app/Console/Commands/BybitLifecycle.php
@@ -83,6 +83,8 @@ class BybitLifecycle extends Command
 
         // --- Sync P&L records ---
         $this->syncPnlRecords('ETHUSDT');
+
+        return self::SUCCESS;
     }
 
     private function syncPnlRecords(string $symbol)


### PR DESCRIPTION
The `handle` method in the `BybitLifecycle` command was missing a return statement, causing a `TypeError`. This commit adds the missing return statement to ensure the command returns an integer status code as required.