### PR TITLE
fix: Improve Bybit API error logging

### DIFF
--- a/app/Services/BybitApiService.php
+++ b/app/Services/BybitApiService.php
@@ -57,7 +57,11 @@ class BybitApiService
             $errorCode = $responseData['retCode'] ?? 'N/A';
             $errorMsg = $responseData['retMsg'] ?? 'Unknown error';
             $requestBody = json_encode($params);
-            throw new \Exception("Bybit API Error on {$endpoint}. Code: {$errorCode}, Msg: {$errorMsg}, Request: {$requestBody}");
+            // Add the full response body to the exception message for better debugging.
+            $fullResponse = $response->body();
+            throw new \Exception(
+                "Bybit API Error on {$endpoint}. Code: {$errorCode}, Msg: {$errorMsg}, Request: {$requestBody}, Full Response: {$fullResponse}"
+            );
         }
 
         return $responseData['result'];


### PR DESCRIPTION
This commit improves the error logging in the `BybitApiService` to include the full response body in the exception message. This will help diagnose API errors more effectively.