### PR TITLE
feat: Add validation to prevent orders within SL/TP range

### DIFF
--- a/tests/Feature/BybitControllerTest.php
+++ b/tests/Feature/BybitControllerTest.php
@@ -200,4 +200,35 @@ class BybitControllerTest extends TestCase
         // Assert
         $response->assertSessionHas('success');
     }
+
+    /**
+     * @test
+     */
+    public function it_prevents_creating_an_order_within_the_sl_tp_range_of_a_filled_order()
+    {
+        // Arrange
+        Order::create([
+            'status' => 'filled',
+            'entry_price' => 2500,
+            'tp' => 2600,
+            'sl' => 2400,
+        ]);
+
+        $postData = [
+            'entry1' => 2450, // This is within the 2400-2600 range
+            'entry2' => 2450,
+            'tp' => 2700,
+            'sl' => 2300,
+            'steps' => 1,
+            'expire' => 15,
+            'risk_percentage' => 1,
+        ];
+
+        // Act
+        $response = $this->actingAs($this->user)->post(route('order.store'), $postData);
+
+        // Assert
+        $response->assertSessionHasErrors('msg');
+        $this->assertDatabaseMissing('orders', ['entry_price' => 2450]);
+    }
 }


### PR DESCRIPTION
This commit adds a new validation rule to the order creation process. It prevents a new order from being created if its entry price falls between the Stop Loss and Take Profit prices of an existing "filled" order.