### PR TITLE
feat: Add refined validation for new orders

### DIFF
--- a/app/Http/Controllers/BybitController.php
+++ b/app/Http/Controllers/BybitController.php
@@ -70,15 +70,52 @@ class BybitController extends Controller
                 return back()->withErrors(['msg' => "به دلیل ضرر در معامله اخیر، تا {$remainingTime} دقیقه دیگر نمی‌توانید معامله جدیدی ثبت کنید."])->withInput();
             }
 
-            // New validation: Check against active filled order's SL/TP range
+            // New validation: Check against active filled order's zones
             $filledOrder = Order::where('status', 'filled')->first();
             if ($filledOrder) {
-                $newAvgEntry = (($request->input('entry1') + $request->input('entry2')) / 2);
-                $minPrice = min($filledOrder->sl, $filledOrder->tp);
-                $maxPrice = max($filledOrder->sl, $filledOrder->tp);
+                $newAvgEntry = ($request->input('entry1') + $request->input('entry2')) / 2;
+                $newSide = ($request->input('sl') > $newAvgEntry) ? 'Sell' : 'Buy';
 
-                if ($newAvgEntry >= $minPrice && $newAvgEntry <= $maxPrice) {
-                    return back()->withErrors(['msg' => "قیمت ورود جدید در محدوده سود و زیان معامله فعال فعلی قرار دارد."])->withInput();
+                // Define the zones
+                $lossZoneMin = min($filledOrder->entry_price, $filledOrder->sl);
+                $lossZoneMax = max($filledOrder->entry_price, $filledOrder->sl);
+                $profitZoneMin = min($filledOrder->entry_price, $filledOrder->tp);
+                $profitZoneMax = max($filledOrder->entry_price, $filledOrder->tp);
+
+                // Check Loss Zone (No-Go Zone)
+                if ($newAvgEntry >= $lossZoneMin && $newAvgEntry <= $lossZoneMax) {
+                    return back()->withErrors(['msg' => 'قیمت ورود جدید در محدوده ضرر معامله فعال قرار دارد و مجاز نیست.'])->withInput();
+                }
+
+                // Check Profit Zone (Conditional Zone)
+                if ($newAvgEntry >= $profitZoneMin && $newAvgEntry <= $profitZoneMax) {
+                    if (strtolower($newSide) === strtolower($filledOrder->side)) {
+                        return back()->withErrors(['msg' => 'ثبت سفارش هم‌جهت در محدوده سود معامله فعال مجاز نیست.'])->withInput();
+                    }
+                }
+            }
+            // New validation: Check against active filled order's zones
+            $filledOrder = Order::where('status', 'filled')->first();
+            if ($filledOrder) {
+                $newAvgEntry = ($request->input('entry1') + $request->input('entry2')) / 2;
+                $newSide = ($request->input('sl') > $newAvgEntry) ? 'Sell' : 'Buy';
+
+                // Define the zones
+                $lossZoneMin = min($filledOrder->entry_price, $filledOrder->sl);
+                $lossZoneMax = max($filledOrder->entry_price, $filledOrder->sl);
+                $profitZoneMin = min($filledOrder->entry_price, $filledOrder->tp);
+                $profitZoneMax = max($filledOrder->entry_price, $filledOrder->tp);
+
+                // Check Loss Zone (No-Go Zone)
+                if ($newAvgEntry >= $lossZoneMin && $newAvgEntry <= $lossZoneMax) {
+                    return back()->withErrors(['msg' => 'قیمت ورود جدید در محدوده ضرر معامله فعال قرار دارد و مجاز نیست.'])->withInput();
+                }
+
+                // Check Profit Zone (Conditional Zone)
+                if ($newAvgEntry >= $profitZoneMin && $newAvgEntry <= $profitZoneMax) {
+                    if (strtolower($newSide) === strtolower($filledOrder->side)) {
+                        return back()->withErrors(['msg' => 'ثبت سفارش هم‌جهت در محدوده سود معامله فعال مجاز نیست.'])->withInput();
+                    }
                 }
             }
 


### PR DESCRIPTION
This commit introduces a more detailed validation rule when creating a new order while another is active.
- New orders are forbidden if their entry price is in the "loss zone" (between the active order's entry and stop loss).
- New orders are forbidden if they are in the "profit zone" (between entry and take profit) AND have the same direction as the active order.
- New orders of the opposite direction in the profit zone are allowed.