### PR TITLE
feat: Add MACD Strategy page and price saving command

### DIFF
--- a/app/Services/TechnicalAnalysisService.php
+++ b/app/Services/TechnicalAnalysisService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Services;
+
+class TechnicalAnalysisService
+{
+    /**
+     * Calculate the Simple Moving Average (SMA).
+     *
+     * @param array $data
+     * @param int $period
+     * @return array
+     */
+    public function sma(array $data, int $period): array
+    {
+        $sma = [];
+        $dataCount = count($data);
+        for ($i = $period - 1; $i < $dataCount; $i++) {
+            $sum = 0;
+            for ($j = 0; $j < $period; $j++) {
+                $sum += $data[$i - $j];
+            }
+            $sma[] = $sum / $period;
+        }
+        return $sma;
+    }
+
+    /**
+     * Calculate the Exponential Moving Average (EMA).
+     *
+     * @param array $data
+     * @param int $period
+     * @return array
+     */
+    public function ema(array $data, int $period): array
+    {
+        $ema = [];
+        $multiplier = 2 / ($period + 1);
+        $initialSma = $this->sma(array_slice($data, 0, $period), $period);
+        $ema[] = $initialSma[0];
+
+        $dataCount = count($data);
+        for ($i = $period; $i < $dataCount; $i++) {
+            $emaValue = ($data[$i] - end($ema)) * $multiplier + end($ema);
+            $ema[] = $emaValue;
+        }
+
+        return $ema;
+    }
+
+    /**
+     * Calculate the Moving Average Convergence Divergence (MACD).
+     *
+     * @param array $data
+     * @param int $fastPeriod
+     * @param int $slowPeriod
+     * @param int $signalPeriod
+     * @return array|null
+     */
+    public function macd(array $data, int $fastPeriod = 12, int $slowPeriod = 26, int $signalPeriod = 9): ?array
+    {
+        $dataCount = count($data);
+        if ($dataCount < $slowPeriod) {
+            return null;
+        }
+
+        $emaFast = $this->ema($data, $fastPeriod);
+        $emaSlow = $this->ema($data, $slowPeriod);
+
+        $macdLine = [];
+        $emaFastSlice = array_slice($emaFast, $slowPeriod - $fastPeriod);
+
+        foreach ($emaSlow as $key => $value) {
+            $macdLine[] = $emaFastSlice[$key] - $value;
+        }
+
+        if (count($macdLine) < $signalPeriod) {
+            return null;
+        }
+
+        $signalLine = $this->ema($macdLine, $signalPeriod);
+
+        $histogram = [];
+        $macdLineSlice = array_slice($macdLine, $signalPeriod - 1);
+
+        foreach ($signalLine as $key => $value) {
+            $histogram[] = $macdLineSlice[$key] - $value;
+        }
+
+        return [
+            'macd' => array_slice($macdLineSlice, -count($histogram)),
+            'signal' => $signalLine,
+            'histogram' => $histogram,
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
         "guzzlehttp/guzzle": "^7.2",
         "laravel/framework": "^10.10",
         "laravel/sanctum": "^3.3",
-        "laravel/tinker": "^2.8",
-        "timirey/trader-php": "0.1.0"
+        "laravel/tinker": "^2.8"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a0463fb310e4ca2a6de3e97e7242bb1",
+    "content-hash": "9c491b8531eec05ba41a11d9276a5749",
     "packages": [
         {
             "name": "brick/math",
@@ -5457,59 +5457,6 @@
                 "source": "https://github.com/tijsverkoyen/CssToInlineStyles/tree/v2.3.0"
             },
             "time": "2024-12-21T16:25:41+00:00"
-        },
-        {
-            "name": "timirey/trader-php",
-            "version": "0.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/timirey/trader-php.git",
-                "reference": "6995ff49efbe00739c53f6403a44537188e8ca9f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/timirey/trader-php/zipball/6995ff49efbe00739c53f6403a44537188e8ca9f",
-                "reference": "6995ff49efbe00739c53f6403a44537188e8ca9f",
-                "shasum": ""
-            },
-            "require": {
-                "ext-trader": "*",
-                "php": "^8.3"
-            },
-            "require-dev": {
-                "mockery/mockery": "1.*",
-                "pestphp/pest": "2.*",
-                "phpstan/phpstan": "1.*",
-                "slevomat/coding-standard": "8.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Timirey\\Trader\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Artiom Misiru",
-                    "email": "misiru.artiom@gmail.com",
-                    "role": "Certified Web Developer"
-                }
-            ],
-            "description": "PHP wrapper for the trader extension, providing access to technical analysis indicators.",
-            "keywords": [
-                "indicators",
-                "php",
-                "trading"
-            ],
-            "support": {
-                "issues": "https://github.com/timirey/trader-php/issues",
-                "source": "https://github.com/timirey/trader-php/tree/0.1.0"
-            },
-            "time": "2024-11-24T16:00:10+00:00"
         },
         {
             "name": "vlucas/phpdotenv",


### PR DESCRIPTION
This commit introduces two main features:
1. A command to save historical k-line data for a list of markets from the Binance public API.
2. A new "MACD Strategy" page that displays normalized MACD values for selected markets.

The `prices:save` command fetches k-line data for 17 predefined markets and saves the last 50 records for multiple timeframes (1m, 5m, 15m, 1h, 4h, 1d) into a new `prices` table.

The "MACD Strategy" page is accessible only to users in "strict mode" and can be found under the "Futures" dropdown. It calculates and displays the normalized MACD for BTC/USDT, ETH/USDT, and a user-selectable market across the different timeframes, allowing for comparison.

This commit also includes:
- A new `prices` table migration and `Price` model.
- A new `MACDStrategyController` and view.
- A new `getKlines` method in the `BinanceApiService`.
- A new `TechnicalAnalysisService` to manually calculate MACD, SMA, and EMA, removing the need for the `trader` PHP extension.