### PR TITLE
feat: Add MACD Strategy page and price saving command

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -56,7 +56,7 @@ class LoginController extends Controller
         Auth::login($user, $request->filled('remember'));
         $request->session()->regenerate();
         
-        return redirect()->intended(route('orders.index'));
+        return redirect()->intended(route('futures.orders'));
     }
 
     public function logout(Request $request)

--- a/app/Http/Controllers/FuturesController.php
+++ b/app/Http/Controllers/FuturesController.php
@@ -181,7 +181,7 @@ class FuturesController extends Controller
             ->latest('updated_at')
             ->paginate(20);
 
-        return view('orders_list', [
+        return view('futures.orders_list', [
             'orders' => $orders,
             'hasActiveExchange' => $exchangeStatus['hasActiveExchange'],
             'exchangeMessage' => $exchangeStatus['message']
@@ -232,7 +232,7 @@ class FuturesController extends Controller
         // Set default expiration based on strict mode
         $defaultExpiration = $user->future_strict_mode ? 15 : 999;
         
-        return view('set_order', [
+        return view('futures.set_order', [
             'marketPrice' => $marketPrice,
             'hasActiveExchange' => $exchangeStatus['hasActiveExchange'],
             'exchangeMessage' => $exchangeStatus['message'],
@@ -489,7 +489,7 @@ class FuturesController extends Controller
         // Check if user has active exchange
         $exchangeStatus = $this->checkActiveExchange();
         if (!$exchangeStatus['hasActiveExchange']) {
-            return redirect()->route('orders.index')
+            return redirect()->route('futures.orders')
                 ->withErrors(['msg' => $exchangeStatus['message']]);
         }
         
@@ -498,7 +498,7 @@ class FuturesController extends Controller
         $userExchangeIds = $user->activeExchanges()->pluck('id')->toArray();
         
         if (!in_array($order->user_exchange_id, $userExchangeIds)) {
-            return redirect()->route('orders.index')
+            return redirect()->route('futures.orders')
                 ->withErrors(['msg' => 'شما مجاز به حذف این سفارش نیستید.']);
         }
         
@@ -541,11 +541,11 @@ class FuturesController extends Controller
                 'status' => $status,
                 'user_exchange_id' => $order->user_exchange_id
             ]);
-            return redirect()->route('orders.index')->with('success', "سفارش {$status} با موفقیت حذف شد.");
+            return redirect()->route('futures.orders')->with('success', "سفارش {$status} با موفقیت حذف شد.");
         }
 
         // For any other status, do nothing.
-        return redirect()->route('orders.index')->withErrors(['msg' => 'این سفارش قابل حذف نیست.']);
+        return redirect()->route('futures.orders')->withErrors(['msg' => 'این سفارش قابل حذف نیست.']);
     }
 
     public function close(Request $request, Order $order)
@@ -553,7 +553,7 @@ class FuturesController extends Controller
         // Check if user has active exchange
         $exchangeStatus = $this->checkActiveExchange();
         if (!$exchangeStatus['hasActiveExchange']) {
-            return redirect()->route('orders.index')
+            return redirect()->route('futures.orders')
                 ->withErrors(['msg' => $exchangeStatus['message']]);
         }
         
@@ -562,7 +562,7 @@ class FuturesController extends Controller
         $userExchangeIds = $user->activeExchanges()->pluck('id')->toArray();
         
         if (!in_array($order->user_exchange_id, $userExchangeIds)) {
-            return redirect()->route('orders.index')
+            return redirect()->route('futures.orders')
                 ->withErrors(['msg' => 'شما مجاز به بستن این سفارش نیستید.']);
         }
         
@@ -571,7 +571,7 @@ class FuturesController extends Controller
         ]);
 
         if ($order->status !== 'filled') {
-            return redirect()->route('orders.index')->withErrors(['msg' => 'فقط سفارش‌های پر شده قابل بستن هستند.']);
+            return redirect()->route('futures.orders')->withErrors(['msg' => 'فقط سفارش‌های پر شده قابل بستن هستند.']);
         }
 
         try {
@@ -625,7 +625,7 @@ class FuturesController extends Controller
 
             $exchangeService->createOrder($newTpOrderParams);
 
-            return redirect()->route('orders.index')->with('success', "سفارش بسته شدن دستی با قیمت {$closePrice} ثبت شد.");
+            return redirect()->route('futures.orders')->with('success', "سفارش بسته شدن دستی با قیمت {$closePrice} ثبت شد.");
 
         } catch (\Exception $e) {
             Log::error('Futures order close failed: ' . $e->getMessage());
@@ -633,7 +633,7 @@ class FuturesController extends Controller
             // Parse Bybit error message for user-friendly response
             $userFriendlyMessage = $this->parseBybitError($e->getMessage());
             
-            return redirect()->route('orders.index')->withErrors(['msg' => $userFriendlyMessage]);
+            return redirect()->route('futures.orders')->withErrors(['msg' => $userFriendlyMessage]);
         }
     }
     

--- a/app/Http/Controllers/PnlHistoryController.php
+++ b/app/Http/Controllers/PnlHistoryController.php
@@ -14,6 +14,6 @@ class PnlHistoryController extends Controller
             ->latest('closed_at')
             ->paginate(20);
 
-        return view('pnl_history', ['positions' => $trades]);
+        return view('futures.pnl_history', ['positions' => $trades]);
     }
 }

--- a/resources/views/futures/orders_list.blade.php
+++ b/resources/views/futures/orders_list.blade.php
@@ -178,10 +178,10 @@
     <!-- Mobile redirect buttons (only visible on mobile) -->
     <div class="mobile-redirect-section">
         <div class="redirect-buttons">
-            <a href="{{ route('orders.index') }}" class="redirect-btn">
+            <a href="{{ route('futures.orders') }}" class="redirect-btn">
                 📊 سفارش‌های آتی
             </a>
-            <a href="{{ route('pnl.history') }}" class="redirect-btn secondary">
+            <a href="{{ route('futures.pnl_history') }}" class="redirect-btn secondary">
                 📈 سود و زیان
             </a>
         </div>
@@ -210,7 +210,7 @@
                         <td data-label="وضعیت">{{ $order->status }}</td>
                         <td data-label="عملیات">
                             @if($order->status === 'pending')
-                                <form action="{{ route('orders.destroy', $order) }}" method="POST" style="display:inline;" onsubmit="return confirm('آیا از لغو این سفارش مطمئن هستید؟');">
+                                <form action="{{ route('futures.orders.destroy', $order) }}" method="POST" style="display:inline;" onsubmit="return confirm('آیا از لغو این سفارش مطمئن هستید؟');">
                                     @csrf
                                     @method('DELETE')
                                     <button type="submit" class="delete-btn">لغو کردن</button>
@@ -218,7 +218,7 @@
                             @elseif($order->status === 'filled')
                                 <button type="button" class="close-btn" data-order-id="{{ $order->id }}" data-order-side="{{ $order->side }}">بستن</button>
                             @elseif($order->status === 'expired')
-                                <form action="{{ route('orders.destroy', $order) }}" method="POST" style="display:inline;" onsubmit="return confirm('آیا از حذف این سفارش منقضی شده مطمئن هستید؟');">
+                                <form action="{{ route('futures.orders.destroy', $order) }}" method="POST" style="display:inline;" onsubmit="return confirm('آیا از حذف این سفارش منقضی شده مطمئن هستید؟');">
                                     @csrf
                                     @method('DELETE')
                                     <button type="submit" class="delete-btn">حذف</button>

--- a/resources/views/futures/pnl_history.blade.php
+++ b/resources/views/futures/pnl_history.blade.php
@@ -145,10 +145,10 @@
     <!-- Mobile redirect buttons (only visible on mobile) -->
     <div class="mobile-redirect-section">
         <div class="redirect-buttons">
-            <a href="{{ route('orders.index') }}" class="redirect-btn">
+            <a href="{{ route('futures.orders') }}" class="redirect-btn">
                 📊 سفارش‌های آتی
             </a>
-            <a href="{{ route('pnl.history') }}" class="redirect-btn secondary">
+            <a href="{{ route('futures.pnl_history') }}" class="redirect-btn secondary">
                 📈 سود و زیان
             </a>
         </div>

--- a/resources/views/futures/set_order.blade.php
+++ b/resources/views/futures/set_order.blade.php
@@ -121,7 +121,7 @@
         </div>
     @endif
 
-    <form action="{{ route('order.store') }}" method="POST" id="order-form">
+    <form action="{{ route('futures.order.store') }}" method="POST" id="order-form">
         @csrf
 
         @if(isset($user) && $user->future_strict_mode)

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -141,9 +141,9 @@
         <div style="display: inline-block; position: relative; margin: 0 15px;">
             <a href="#" style="cursor: pointer;" onclick="toggleFuturesMenu(event)">معاملات آتی ▼</a>
             <div id="futuresMenu" class="dropdown-list">
-                <a href="{{ route('orders.index') }}">تاریخچه سفارش‌ها</a>
-                <a href="{{ route('pnl.history') }}">سود و زیان</a>
-                <a href="{{ route('order.create') }}">سفارش آتی جدید</a>
+                <a href="{{ route('futures.orders') }}">تاریخچه سفارش‌ها</a>
+                <a href="{{ route('futures.pnl_history') }}">سود و زیان</a>
+                <a href="{{ route('futures.order.create') }}">سفارش آتی جدید</a>
                 @if(auth()->user()?->future_strict_mode)
                     <a href="{{ route('futures.macd_strategy') }}">MACD Strategy</a>
                 @endif
@@ -185,11 +185,11 @@
 
 <!-- Mobile Sticky Footer -->
 <nav class="mobile-footer-nav">
-    <a href="{{ route('orders.index') }}">
+    <a href="{{ route('futures.orders') }}">
         <span class="icon">📊</span>
         <span>سفارش‌ها</span>
     </a>
-    <a href="{{ route('order.create') }}">
+    <a href="{{ route('futures.order.create') }}">
         <span class="icon">➕</span>
         <span>جدید</span>
     </a>

--- a/resources/views/macd/index.blade.php
+++ b/resources/views/macd/index.blade.php
@@ -1,75 +1,128 @@
-<x-app-layout>
-    <x-slot name="header">
-        <h2 class="font-semibold text-xl text-gray-800 leading-tight">
-            {{ __('MACD Strategy') }}
-        </h2>
-    </x-slot>
+@extends('layouts.app')
 
-    <div class="py-12">
-        <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-            <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="p-6 bg-white border-b border-gray-200">
+@section('title', 'MACD Strategy')
 
-                    <form method="GET" action="{{ route('futures.macd_strategy') }}" class="mb-4">
-                        <label for="market" class="mr-2">Select a market to compare:</label>
-                        <select name="market" id="market" class="border-gray-300 focus:border-indigo-300 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 rounded-md shadow-sm">
-                            @foreach($markets as $market)
-                                <option value="{{ $market }}" {{ $selectedMarket == $market ? 'selected' : '' }}>
-                                    {{ $market }}
-                                </option>
-                            @endforeach
-                        </select>
-                        <button type="submit" class="ml-2 px-4 py-2 bg-gray-800 border border-transparent rounded-md font-semibold text-xs text-white uppercase tracking-widest hover:bg-gray-700 active:bg-gray-900 focus:outline-none focus:border-gray-900 focus:ring ring-gray-300 disabled:opacity-25 transition ease-in-out duration-150">
-                            Compare
-                        </button>
-                    </form>
+@push('styles')
+    <style>
+        .container {
+            width: 100%;
+            max-width: 1200px;
+            margin: auto;
+        }
+        .strategy-card {
+            padding: 30px;
+            border-radius: 15px;
+            box-shadow: 0 8px 25px rgba(0,0,0,0.1);
+            margin-bottom: 20px;
+        }
+        .strategy-card h2 {
+            margin-bottom: 30px;
+            text-align: center;
+            color: var(--primary-color);
+        }
+        .table-responsive {
+            overflow-x: auto;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+        }
+        th, td {
+            padding: 12px 15px;
+            text-align: right;
+            border-bottom: 1px solid #ddd;
+        }
+        thead th {
+            background-color: #f5f5f5;
+            font-weight: bold;
+        }
+        tbody tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+        .form-group {
+            margin-bottom: 20px;
+        }
+        label {
+            font-weight: bold;
+        }
+        select {
+            width: 100%;
+            max-width: 300px;
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+        }
+        .btn {
+            display: inline-block;
+            padding: 12px 20px;
+            margin: 5px;
+            text-decoration: none;
+            border-radius: 8px;
+            font-weight: bold;
+            transition: opacity 0.3s;
+            border: none;
+            cursor: pointer;
+            font-size: 14px;
+        }
+        .btn-primary {
+            background-color: var(--primary-color);
+            color: white;
+        }
+    </style>
+@endpush
 
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-gray-50">
-                                <tr>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                        Timeframe
-                                    </th>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                        Market
-                                    </th>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                        Normalized MACD
-                                    </th>
-                                    <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                                        Normalized Signal
-                                    </th>
-                                </tr>
-                            </thead>
-                            <tbody class="bg-white divide-y divide-gray-200">
-                                @foreach($timeframes as $timeframe)
-                                    @foreach(['BTCUSDT', 'ETHUSDT', $selectedMarket] as $market)
-                                        @if(isset($macdData[$timeframe][$market]))
-                                            <tr>
-                                                <td class="px-6 py-4 whitespace-nowrap">{{ $timeframe }}</td>
-                                                <td class="px-6 py-4 whitespace-nowrap">{{ $market }}</td>
-                                                <td class="px-6 py-4 whitespace-nowrap">{{ number_format($macdData[$timeframe][$market]['normalized_macd'], 4) }}</td>
-                                                <td class="px-6 py-4 whitespace-nowrap">{{ number_format($macdData[$timeframe][$market]['normalized_signal'], 4) }}</td>
-                                            </tr>
-                                        @else
-                                            <tr>
-                                                <td class="px-6 py-4 whitespace-nowrap">{{ $timeframe }}</td>
-                                                <td class="px-6 py-4 whitespace-nowrap">{{ $market }}</td>
-                                                <td colspan="2" class="px-6 py-4 whitespace-nowrap text-red-500">Not enough data</td>
-                                            </tr>
-                                        @endif
-                                    @endforeach
-                                    <tr class="bg-gray-100">
-                                        <td colspan="4" class="px-6 py-1"></td>
+@section('content')
+    <div class="glass-card container">
+        <div class="strategy-card">
+            <h2>MACD Strategy Comparison</h2>
+
+            <form method="GET" action="{{ route('futures.macd_strategy') }}" class="form-group">
+                <label for="market">Select a market to compare:</label>
+                <select name="market" id="market" onchange="this.form.submit()">
+                    @foreach($markets as $marketOption)
+                        <option value="{{ $marketOption }}" {{ $selectedMarket == $marketOption ? 'selected' : '' }}>
+                            {{ $marketOption }}
+                        </option>
+                    @endforeach
+                </select>
+            </form>
+
+            <div class="table-responsive">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Timeframe</th>
+                            <th>Market</th>
+                            <th>Normalized MACD</th>
+                            <th>Normalized Signal</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($timeframes as $timeframe)
+                            @foreach(['BTCUSDT', 'ETHUSDT', $selectedMarket] as $market)
+                                @if(isset($macdData[$timeframe][$market]))
+                                    <tr>
+                                        <td>{{ $timeframe }}</td>
+                                        <td>{{ $market }}</td>
+                                        <td>{{ number_format($macdData[$timeframe][$market]['normalized_macd'], 4) }}</td>
+                                        <td>{{ number_format($macdData[$timeframe][$market]['normalized_signal'], 4) }}</td>
                                     </tr>
-                                @endforeach
-                            </tbody>
-                        </table>
-                    </div>
-
-                </div>
+                                @else
+                                    <tr>
+                                        <td>{{ $timeframe }}</td>
+                                        <td>{{ $market }}</td>
+                                        <td colspan="2" style="color: red;">Not enough data</td>
+                                    </tr>
+                                @endif
+                            @endforeach
+                            <tr style="background-color: #e0e0e0;">
+                                <td colspan="4" style="height: 2px;"></td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
             </div>
+
         </div>
     </div>
-</x-app-layout>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,13 +45,19 @@ Route::post('password/reset', [PasswordController::class, 'resetPassword'])->nam
 Route::get('api-documentation', [ApiDocumentationController::class, 'index'])->name('api.documentation');
 
 Route::middleware(['auth'])->group(function () {
-    Route::get('/', [FuturesController::class, 'index'])->middleware('exchange.access:futures'); // Redirect home to orders list
-    Route::get('/set-order', [FuturesController::class, 'create'])->name('order.create')->middleware('exchange.access:futures');
-    Route::post('/set-order', [FuturesController::class, 'store'])->name('order.store')->middleware('exchange.access:futures');
-    Route::get('/orders', [FuturesController::class, 'index'])->name('orders.index')->middleware('exchange.access:futures');
-    Route::post('/orders/{order}/close', [FuturesController::class, 'close'])->name('orders.close')->middleware('exchange.access:futures');
-    Route::delete('/orders/{order}', [FuturesController::class, 'destroy'])->name('orders.destroy')->middleware('exchange.access:futures');
-    Route::get('/pnl-history', [PnlHistoryController::class, 'index'])->name('pnl.history')->middleware('exchange.access:futures');
+    Route::get('/', function () {
+        return redirect()->route('futures.orders');
+    });
+
+    Route::prefix('futures')->name('futures.')->middleware('exchange.access:futures')->group(function () {
+        Route::get('/orders', [FuturesController::class, 'index'])->name('orders');
+        Route::get('/set-order', [FuturesController::class, 'create'])->name('order.create');
+        Route::post('/set-order', [FuturesController::class, 'store'])->name('order.store');
+        Route::post('/orders/{order}/close', [FuturesController::class, 'close'])->name('orders.close');
+        Route::delete('/orders/{order}', [FuturesController::class, 'destroy'])->name('orders.destroy');
+        Route::get('/pnl-history', [PnlHistoryController::class, 'index'])->name('pnl_history');
+        Route::get('/macd-strategy', [MACDStrategyController::class, 'index'])->name('macd_strategy');
+    });
     Route::get('/profile', [ProfileController::class, 'index'])->name('profile.index');
     Route::get('/profile/show', [ProfileController::class, 'index'])->name('profile.show');
 
@@ -62,9 +68,6 @@ Route::middleware(['auth'])->group(function () {
     // Settings Routes (requires authentication)
     Route::get('/settings', [SettingsController::class, 'index'])->name('settings.index');
     Route::post('/settings/activate-future-strict-mode', [SettingsController::class, 'activateFutureStrictMode'])->name('settings.activate-future-strict-mode');
-
-    // MACD Strategy Route
-    Route::get('/futures/macd-strategy', [MACDStrategyController::class, 'index'])->name('futures.macd_strategy');
 
     // Exchange Management Routes (requires authentication)
     Route::prefix('exchanges')->group(function () {


### PR DESCRIPTION
This commit introduces two main features:
1. A command to save historical k-line data for a list of markets from the Binance public API.
2. A new "MACD Strategy" page that displays normalized MACD values for selected markets.

The `prices:save` command fetches k-line data for 17 predefined markets and saves the last 50 records for multiple timeframes (1m, 5m, 15m, 1h, 4h, 1d) into a new `prices` table.

The "MACD Strategy" page is accessible only to users in "strict mode" and can be found under the "Futures" dropdown. It calculates and displays the normalized MACD for BTC/USDT, ETH/USDT, and a user-selectable market across the different timeframes, allowing for comparison.

This commit also includes:
- A new `prices` table migration and `Price` model.
- A new `MACDStrategyController` and view, with corrected layout and styling.
- A new `getKlines` method in the `BinanceApiService`.
- A new `TechnicalAnalysisService` to manually calculate MACD, SMA, and EMA.
- Restructuring of the futures-related views and routes.