### PR TITLE
feat: Add MACD Strategy page and price saving command

### DIFF
--- a/app/Services/Exchanges/BinanceApiService.php
+++ b/app/Services/Exchanges/BinanceApiService.php
@@ -88,15 +88,21 @@ class BinanceApiService implements ExchangeApiServiceInterface
     /**
      * Get k-line/candlestick data.
      */
-    public function getKlines(string $symbol, string $interval, int $limit = 50): array
+    public function getKlines(string $symbol, string $interval, int $limit = 50, ?int $startTime = null): array
     {
         try {
+            $query = [
+                'symbol' => $symbol,
+                'interval' => $interval,
+                'limit' => $limit,
+            ];
+
+            if ($startTime) {
+                $query['startTime'] = $startTime;
+            }
+
             $response = $this->client->get('/api/v3/klines', [
-                'query' => [
-                    'symbol' => $symbol,
-                    'interval' => $interval,
-                    'limit' => $limit,
-                ]
+                'query' => $query
             ]);
 
             $data = json_decode($response->getBody(), true);


### PR DESCRIPTION
This commit introduces two main features and a refactoring of the futures-related views and routes:
1. A command to save historical k-line data for a list of markets from the Binance public API.
2. A new "MACD Strategy" page that displays normalized MACD values for selected markets.

The `prices:save` command fetches k-line data for 17 predefined markets and saves the last 50 records for multiple timeframes (1m, 5m, 15m, 1h, 4h, 1d) into a new `prices` table. The command now fetches data incrementally to improve efficiency.

The "MACD Strategy" page is accessible only to users in "strict mode" and can be found under the "Futures" dropdown. It calculates and displays the normalized MACD for BTC/USDT, ETH/USDT, and a user-selectable market across the different timeframes, allowing for comparison. The UI has been translated to Persian and includes a trend indicator.

This commit also includes:
- A new `prices` table migration and `Price` model.
- A new `MACDStrategyController` and view, with corrected layout and styling.
- A new `getKlines` method in the `BinanceApiService`.
- A new `TechnicalAnalysisService` to manually calculate MACD, SMA, and EMA.
- Restructuring of the futures-related views and routes for better organization.