### PR TITLE
feat: Add MACD Strategy page and price saving command

### DIFF
--- a/app/Console/Commands/SavePrices.php
+++ b/app/Console/Commands/SavePrices.php
@@ -47,7 +47,10 @@ class SavePrices extends Command
                 DB::beginTransaction();
                 try {
                     $latestPrice = Price::where('market', $market)->where('timeframe', $timeframe)->orderBy('timestamp', 'desc')->first();
-                    $startTime = $latestPrice ? ($latestPrice->timestamp->getTimestamp() * 1000) + 1 : null;
+                    $startTime = null;
+                    if ($latestPrice && $latestPrice->timestamp instanceof \Carbon\Carbon) {
+                        $startTime = $latestPrice->timestamp->getTimestamp() * 1000 + 1;
+                    }
 
                     $this->info("Fetching k-lines for {$market} on timeframe {$timeframe}...");
                     $klineData = $exchangeService->getKlines($market, $timeframe, 50, $startTime);

--- a/app/Http/Controllers/MACDStrategyController.php
+++ b/app/Http/Controllers/MACDStrategyController.php
@@ -42,19 +42,22 @@ class MACDStrategyController extends Controller
             $altcoinMacdData = $this->calculateMACD($altcoinPrices);
             $baseMarketMacdData = $this->calculateMACD($baseMarketPrices);
 
-            $trend = '⚪'; // Neutral
+            $trend = 'neutral';
+            $trendPower = 0;
             if ($altcoinMacdData && $baseMarketMacdData) {
                 if ($altcoinMacdData['normalized_macd'] > $baseMarketMacdData['normalized_macd']) {
-                    $trend = '🔼'; // Up arrow for bullish
+                    $trend = 'up';
                 } elseif ($altcoinMacdData['normalized_macd'] < $baseMarketMacdData['normalized_macd']) {
-                    $trend = '🔽'; // Down arrow for bearish
+                    $trend = 'down';
                 }
+                $trendPower = $altcoinMacdData['histogram_value'];
             }
 
             $comparisonData[$timeframe] = [
                 'altcoin' => $altcoinMacdData,
                 'base' => $baseMarketMacdData,
                 'trend' => $trend,
+                'trend_power' => $trendPower,
             ];
         }
 
@@ -97,7 +100,7 @@ class MACDStrategyController extends Controller
         return [
             'macd' => $lastMacd,
             'signal' => $lastSignal,
-            'histogram' => $lastHistogram,
+            'histogram_value' => $lastHistogram,
             'normalized_macd' => $normalizedMacd,
             'normalized_signal' => $normalizedSignal,
         ];

--- a/app/Models/Price.php
+++ b/app/Models/Price.php
@@ -15,4 +15,8 @@ class Price extends Model
         'price',
         'timestamp',
     ];
+
+    protected $casts = [
+        'timestamp' => 'datetime',
+    ];
 }

--- a/app/Services/Exchanges/BinanceApiService.php
+++ b/app/Services/Exchanges/BinanceApiService.php
@@ -94,11 +94,12 @@ class BinanceApiService implements ExchangeApiServiceInterface
             $query = [
                 'symbol' => $symbol,
                 'interval' => $interval,
-                'limit' => $limit,
             ];
 
             if ($startTime) {
                 $query['startTime'] = $startTime;
+            } else {
+                $query['limit'] = $limit;
             }
 
             $response = $this->client->get('/api/v3/klines', [

--- a/resources/views/macd/index.blade.php
+++ b/resources/views/macd/index.blade.php
@@ -54,13 +54,74 @@
         }
         select {
             width: 100%;
-            max-width: 250px;
+            max-width: 400px;
             padding: 10px;
             border: 1px solid #ddd;
             border-radius: 5px;
         }
-        .base-market-selector label {
-            margin: 0 10px;
+        .switch {
+            position: relative;
+            display: inline-block;
+            width: 90px;
+            height: 34px;
+        }
+        .switch input {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        .slider {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: #ccc;
+            transition: .4s;
+            border-radius: 34px;
+        }
+        .slider:before {
+            position: absolute;
+            content: "";
+            height: 26px;
+            width: 26px;
+            left: 4px;
+            bottom: 4px;
+            background-color: white;
+            transition: .4s;
+            border-radius: 50%;
+        }
+        input:checked + .slider {
+            background-color: #2196F3;
+        }
+        input:checked + .slider:before {
+            transform: translateX(55px);
+        }
+        .slider.round {
+            border-radius: 34px;
+        }
+        .slider.round:before {
+            border-radius: 50%;
+        }
+        .switch-labels {
+            position: absolute;
+            top: 50%;
+            left: 0;
+            right: 0;
+            transform: translateY(-50%);
+            display: flex;
+            justify-content: space-between;
+            padding: 0 10px;
+            color: white;
+            font-weight: bold;
+            pointer-events: none;
+        }
+        .trend-up {
+            color: green;
+        }
+        .trend-down {
+            color: red;
         }
     </style>
 @endpush
@@ -74,7 +135,7 @@
                 <div class="form-container">
                     <div class="form-group">
                         <label for="altcoin">آلتکوین:</label>
-                        <select name="altcoin" id="altcoin">
+                        <select name="altcoin" id="altcoin" onchange="this.form.submit()">
                             @foreach($altcoins as $altcoin)
                                 <option value="{{ $altcoin }}" {{ $selectedAltcoin == $altcoin ? 'selected' : '' }}>
                                     {{ $altcoin }}
@@ -82,12 +143,17 @@
                             @endforeach
                         </select>
                     </div>
-                    <div class="base-market-selector">
+                    <div class="form-group">
                         <label>بازار پایه:</label>
-                        <input type="radio" id="btc" name="base_market" value="BTCUSDT" {{ $baseMarket == 'BTCUSDT' ? 'checked' : '' }}>
-                        <label for="btc">BTCUSDT</label>
-                        <input type="radio" id="eth" name="base_market" value="ETHUSDT" {{ $baseMarket == 'ETHUSDT' ? 'checked' : '' }}>
-                        <label for="eth">ETHUSDT</label>
+                        <label class="switch">
+                            <input type="checkbox" name="base_market_switch" id="base_market_switch" {{ $baseMarket == 'ETHUSDT' ? 'checked' : '' }}>
+                            <span class="slider round"></span>
+                            <div class="switch-labels">
+                                <span>BTC</span>
+                                <span>ETH</span>
+                            </div>
+                        </label>
+                        <input type="hidden" name="base_market" id="base_market" value="{{ $baseMarket }}">
                     </div>
                 </div>
             </form>
@@ -98,7 +164,9 @@
                         <tr>
                             <th>زمان</th>
                             <th>مکدی نرمال شده {{ $selectedAltcoin }}</th>
+                            <th>هیستوگرام {{ $selectedAltcoin }}</th>
                             <th>مکدی نرمال شده {{ $baseMarket }}</th>
+                            <th>هیستوگرام {{ $baseMarket }}</th>
                             <th>روند</th>
                         </tr>
                     </thead>
@@ -114,14 +182,34 @@
                                     @endif
                                 </td>
                                 <td>
+                                    @if(isset($comparisonData[$timeframe]['altcoin']))
+                                        {{ number_format($comparisonData[$timeframe]['altcoin']['histogram_value'], 4) }}
+                                    @else
+                                        <span style="color: red;">داده کافی نیست</span>
+                                    @endif
+                                </td>
+                                <td>
                                     @if(isset($comparisonData[$timeframe]['base']))
                                         {{ number_format($comparisonData[$timeframe]['base']['normalized_macd'], 4) }}
                                     @else
                                         <span style="color: red;">داده کافی نیست</span>
                                     @endif
                                 </td>
-                                <td style="font-size: 1.5em;">
-                                    {{ $comparisonData[$timeframe]['trend'] }}
+                                <td>
+                                    @if(isset($comparisonData[$timeframe]['base']))
+                                        {{ number_format($comparisonData[$timeframe]['base']['histogram_value'], 4) }}
+                                    @else
+                                        <span style="color: red;">داده کافی نیست</span>
+                                    @endif
+                                </td>
+                                <td style="font-size: 1.5em;" class="{{ $comparisonData[$timeframe]['trend'] === 'up' ? 'trend-up' : ($comparisonData[$timeframe]['trend'] === 'down' ? 'trend-down' : '') }}">
+                                    @if($comparisonData[$timeframe]['trend'] === 'up')
+                                        🔼
+                                    @elseif($comparisonData[$timeframe]['trend'] === 'down')
+                                        🔽
+                                    @else
+                                        ⚪
+                                    @endif
                                 </td>
                             </tr>
                         @endforeach
@@ -138,11 +226,18 @@
     document.addEventListener('DOMContentLoaded', function () {
         const form = document.getElementById('strategy-form');
         const altcoinSelect = document.getElementById('altcoin');
-        const baseMarketRadios = document.querySelectorAll('input[name="base_market"]');
+        const baseMarketSwitch = document.getElementById('base_market_switch');
+        const baseMarketInput = document.getElementById('base_market');
 
         altcoinSelect.addEventListener('change', () => form.submit());
-        baseMarketRadios.forEach(radio => {
-            radio.addEventListener('change', () => form.submit());
+
+        baseMarketSwitch.addEventListener('change', () => {
+            if (baseMarketSwitch.checked) {
+                baseMarketInput.value = 'ETHUSDT';
+            } else {
+                baseMarketInput.value = 'BTCUSDT';
+            }
+            form.submit();
         });
     });
 </script>


### PR DESCRIPTION
This commit introduces two main features and a refactoring of the futures-related views and routes:
1. A command to save historical k-line data for a list of markets from the Binance public API.
2. A new "MACD Strategy" page that displays normalized MACD values for selected markets.

The `prices:save` command fetches k-line data for 17 predefined markets and saves the last 50 records for multiple timeframes (1m, 5m, 15m, 1h, 4h, 1d) into a new `prices` table. The command now fetches data incrementally to improve efficiency and has been fixed to prevent data duplication.

The "MACD Strategy" page is accessible only to users in "strict mode" and can be found under the "Futures" dropdown. It calculates and displays the normalized MACD for BTC/USDT, ETH/USDT, and a user-selectable market across the different timeframes, allowing for comparison. The UI has been translated to Persian and includes a trend indicator based on the MACD histogram.

This commit also includes:
- A new `prices` table migration and `Price` model with a `datetime` cast for the `timestamp` attribute.
- A new `MACDStrategyController` and view, with improved layout and styling.
- A new `getKlines` method in the `BinanceApiService`.
- A new `TechnicalAnalysisService` to manually calculate MACD, SMA, and EMA.
- Restructuring of the futures-related views and routes.