### PR TITLE
Refactor: Separate MACD strategy page and improve UI

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -144,9 +144,14 @@
                 <a href="{{ route('futures.orders') }}">تاریخچه سفارش‌ها</a>
                 <a href="{{ route('futures.pnl_history') }}">سود و زیان</a>
                 <a href="{{ route('futures.order.create') }}">سفارش آتی جدید</a>
-                @if(auth()->user()?->future_strict_mode)
-                    <a href="{{ route('futures.macd_strategy') }}">MACD Strategy</a>
-                @endif
+            </div>
+        </div>
+
+        <!-- Strategies Menu -->
+        <div style="display: inline-block; position: relative; margin: 0 15px;">
+            <a href="#" style="cursor: pointer;" onclick="toggleStrategiesMenu(event)">استراتژی‌ها ▼</a>
+            <div id="strategiesMenu" class="dropdown-list">
+                <a href="{{ route('strategies.macd') }}">MACD Strategy</a>
             </div>
         </div>
 
@@ -256,9 +261,11 @@
             const spotMenu = document.getElementById('spotMenu');
             const adminMenu = document.getElementById('adminMenu');
             const futuresMenu = document.getElementById('futuresMenu');
+            const strategiesMenu = document.getElementById('strategiesMenu');
             const spotMenuToggle = event.target.closest('[onclick*="toggleSpotMenu"]');
             const adminMenuToggle = event.target.closest('[onclick*="toggleAdminMenu"]');
             const futuresMenuToggle = event.target.closest('[onclick*="toggleFuturesMenu"]');
+            const strategiesMenuToggle = event.target.closest('[onclick*="toggleStrategiesMenu"]');
 
             if (!spotMenuToggle && spotMenu) {
                 spotMenu.style.display = 'none';
@@ -270,6 +277,10 @@
 
             if (!futuresMenuToggle && futuresMenu) {
                 futuresMenu.style.display = 'none';
+            }
+
+            if (!strategiesMenuToggle && strategiesMenu) {
+                strategiesMenu.style.display = 'none';
             }
         });
     });
@@ -292,6 +303,13 @@
         event.preventDefault();
         event.stopPropagation();
         const menu = document.getElementById('futuresMenu');
+        menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
+    }
+
+    function toggleStrategiesMenu(event) {
+        event.preventDefault();
+        event.stopPropagation();
+        const menu = document.getElementById('strategiesMenu');
         menu.style.display = menu.style.display === 'none' ? 'block' : 'none';
     }
 </script>

--- a/resources/views/macd/index.blade.php
+++ b/resources/views/macd/index.blade.php
@@ -41,6 +41,30 @@
         tbody tr:nth-child(even) {
             background-color: #f9f9f9;
         }
+        @media screen and (max-width: 768px) {
+            table thead { display: none; }
+            table tr {
+                display: block;
+                margin-bottom: 15px;
+                border-radius: 8px;
+                box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+            }
+            table td {
+                display: flex;
+                justify-content: space-between;
+                text-align: right;
+                padding: 10px 15px;
+                border: none;
+                border-bottom: 1px solid rgba(238, 238, 238, 0.25);
+            }
+            table td:last-child { border-bottom: 0; }
+            table td::before {
+                content: attr(data-label);
+                font-weight: bold;
+                padding-left: 10px;
+                text-align: left;
+            }
+        }
         .form-container {
             display: flex;
             justify-content: space-between;
@@ -139,7 +163,7 @@
         <div class="strategy-card">
             <h2> استراتژی MACD</h2>
 
-            <form method="GET" action="{{ route('futures.macd_strategy') }}" id="strategy-form">
+            <form method="GET" action="{{ route('strategies.macd') }}" id="strategy-form">
                 <div class="form-container">
                     <div class="form-group">
                         <label for="altcoin">آلتکوین:</label>
@@ -180,36 +204,36 @@
                     <tbody>
                         @foreach($timeframes as $timeframe)
                             <tr>
-                                <td>{{ $timeframe }}</td>
-                                <td>
+                                <td data-label="زمان">{{ $timeframe }}</td>
+                                <td data-label="مکدی نرمال شده {{ $selectedAltcoin }}">
                                     @if(isset($comparisonData[$timeframe]['altcoin']))
                                         {{ number_format($comparisonData[$timeframe]['altcoin']['normalized_macd'], 4) }}
                                     @else
                                         <span style="color: red;">داده کافی نیست</span>
                                     @endif
                                 </td>
-                                <td>
+                                <td data-label="هیستوگرام نرمال شده {{ $selectedAltcoin }}">
                                     @if(isset($comparisonData[$timeframe]['altcoin']))
                                         {{ number_format($comparisonData[$timeframe]['altcoin']['normalized_histogram'], 4) }}
                                     @else
                                         <span style="color: red;">داده کافی نیست</span>
                                     @endif
                                 </td>
-                                <td>
+                                <td data-label="مکدی نرمال شده {{ $baseMarket }}">
                                     @if(isset($comparisonData[$timeframe]['base']))
                                         {{ number_format($comparisonData[$timeframe]['base']['normalized_macd'], 4) }}
                                     @else
                                         <span style="color: red;">داده کافی نیست</span>
                                     @endif
                                 </td>
-                                <td>
+                                <td data-label="هیستوگرام نرمال شده {{ $baseMarket }}">
                                     @if(isset($comparisonData[$timeframe]['base']))
                                         {{ number_format($comparisonData[$timeframe]['base']['normalized_histogram'], 4) }}
                                     @else
                                         <span style="color: red;">داده کافی نیست</span>
                                     @endif
                                 </td>
-                                <td style="font-size: 1.5em;" class="{{ $comparisonData[$timeframe]['trend'] === 'up' || $comparisonData[$timeframe]['trend'] === 'strong_up' ? 'trend-up' : ($comparisonData[$timeframe]['trend'] === 'down' || $comparisonData[$timeframe]['trend'] === 'strong_down' ? 'trend-down' : '') }}">
+                                <td data-label="روند" style="font-size: 1.5em;" class="{{ $comparisonData[$timeframe]['trend'] === 'up' || $comparisonD ata[$timeframe]['trend'] === 'strong_up' ? 'trend-up' : ($comparisonData[$timeframe]['trend'] === 'down' || $comparisonData[$timeframe]['trend'] === 'strong_down' ? 'trend-down' : '') }}">
                                     @if($comparisonData[$timeframe]['trend'] === 'strong_up')
                                         ⇗
                                     @elseif($comparisonData[$timeframe]['trend'] === 'up')

--- a/routes/web.php
+++ b/routes/web.php
@@ -57,10 +57,13 @@ Route::middleware(['auth'])->group(function () {
         Route::post('/orders/{order}/close', [FuturesController::class, 'close'])->name('orders.close');
         Route::delete('/orders/{order}', [FuturesController::class, 'destroy'])->name('orders.destroy');
         Route::get('/pnl-history', [PnlHistoryController::class, 'index'])->name('pnl_history');
-        Route::get('/macd-strategy', [MACDStrategyController::class, 'index'])->name('macd_strategy');
     });
     Route::get('/profile', [ProfileController::class, 'index'])->name('profile.index');
     Route::get('/profile/show', [ProfileController::class, 'index'])->name('profile.show');
+
+    Route::prefix('strategies')->name('strategies.')->group(function () {
+        Route::get('/macd', [MACDStrategyController::class, 'index'])->name('macd');
+    });
 
     // Password Change Routes (requires authentication)
     Route::get('/password/change', [PasswordController::class, 'showChangePasswordForm'])->name('password.change.form');


### PR DESCRIPTION
- Separated the MACD strategy page into a new 'Strategies' group.
- Made the MACD strategy page accessible to all users by removing the 'strict mode' restriction.
- Updated the navigation menu to include a 'Strategies' dropdown with a link to the MACD page.
- Implemented a responsive mobile view for the MACD strategy page table, matching the style of other tables in the application.