### PR TITLE
Block API for strict mode and improve validation command

### DIFF
--- a/app/Console/Commands/ValidateActiveExchanges.php
+++ b/app/Console/Commands/ValidateActiveExchanges.php
@@ -168,19 +168,16 @@ class ValidateActiveExchanges extends Command
             'overall_success' => $validation['overall'] ?? false
         ]);
         
-        // Special handling for Bybit UNIFIED accounts
-        if ($exchange->exchange_name === 'bybit') {
-            $spotDetails = $validation['spot']['details'] ?? [];
-            $futuresDetails = $validation['futures']['details'] ?? [];
-            
-            $this->line("  Bybit validation details:");
-            $this->line("    Spot: " . ($validation['spot']['success'] ? 'Success' : 'Failed') . " - " . ($validation['spot']['message'] ?? 'No message'));
-            $this->line("    Futures: " . ($validation['futures']['success'] ? 'Success' : 'Failed') . " - " . ($validation['futures']['message'] ?? 'No message'));
-            $this->line("    IP: " . ($validation['ip']['success'] ? 'Success' : 'Failed') . " - " . ($validation['ip']['message'] ?? 'No message'));
-            
-            if (isset($spotDetails['account_type'])) {
-                $this->line("    Account Type: " . $spotDetails['account_type']);
-            }
+        // Generic handling for validation details
+        $this->line("  Validation details:");
+        $this->line("    Spot: " . ($validation['spot']['success'] ? 'Success' : 'Failed') . " - " . ($validation['spot']['message'] ?? 'No message'));
+        $this->line("    Futures: " . ($validation['futures']['success'] ? 'Success' : 'Failed') . " - " . ($validation['futures']['message'] ?? 'No message'));
+        $this->line("    IP: " . ($validation['ip']['success'] ? 'Success' : 'Failed') . " - " . ($validation['ip']['message'] ?? 'No message'));
+
+        // Log extra details if they exist (e.g., account type)
+        $spotDetails = $validation['spot']['details'] ?? [];
+        if (isset($spotDetails['account_type'])) {
+            $this->line("    Account Type: " . $spotDetails['account_type']);
         }
         
         // Update validation results

--- a/app/Http/Controllers/Auth/ApiAuthController.php
+++ b/app/Http/Controllers/Auth/ApiAuthController.php
@@ -54,6 +54,14 @@ class ApiAuthController extends Controller
                 ], 403);
             }
 
+            // Block API access for users in strict mode
+            if ($user->future_strict_mode) {
+                return response()->json([
+                    'success' => false,
+                    'message' => __('messages.api_disabled_strict_mode')
+                ], 403);
+            }
+
             // For demo: Allow login without email verification
             // In production, add email verification check:
             // if (!$user->hasVerifiedEmail()) {

--- a/app/Http/Middleware/ApiTokenAuth.php
+++ b/app/Http/Middleware/ApiTokenAuth.php
@@ -34,6 +34,14 @@ class ApiTokenAuth
             ], 401);
         }
 
+        // Block API access for users in strict mode
+        if ($user->future_strict_mode) {
+            return response()->json([
+                'success' => false,
+                'message' => __('messages.api_disabled_strict_mode')
+            ], 403);
+        }
+
         // Set the authenticated user for this request
         $request->setUserResolver(function () use ($user) {
             return $user;

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'api_disabled_strict_mode' => 'API access is disabled when Future Strict Mode is active.',
+];

--- a/lang/fa/messages.php
+++ b/lang/fa/messages.php
@@ -72,6 +72,7 @@ return [
     'password_reset_sent' => 'لینک بازیابی رمز عبور ارسال شد',
     'invalid_credentials' => 'نام کاربری یا رمز عبور اشتباه است',
     'account_inactive' => 'حساب کاربری شما غیرفعال است',
+    'api_disabled_strict_mode' => 'دسترسی API در حالت سخت‌گیرانه آینده غیرفعال است.',
 
     // Profile
     'profile' => 'پروفایل',


### PR DESCRIPTION
This commit introduces two main improvements:

1.  **API Access for Strict Mode:** Users who have "Future Strict Mode" enabled are now blocked from generating API tokens or making requests to the API. This is enforced in both the `ApiAuthController` and the `ApiTokenAuth` middleware.

2.  **Generic Validation Command:** The `exchanges:validate-active` command has been improved. The detailed console output for validation results is now generic and works for all supported exchanges, not just Bybit. This provides consistent and useful feedback for all configured exchanges.